### PR TITLE
feat(ci): put release notes on every development build

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -80,13 +80,20 @@ jobs:
           cp RecipeLab.apk "RecipeLab-$VERSION_NAME.apk"
           cp RecipeLab.apk RecipeLab-dev.apk
           sha256sum RecipeLab-dev.apk > RecipeLab-dev.apk.sha256
+
+          # The notes come from the same generator and preset as a real release, so a dev
+          # build says what is in it in the same shape people read on the Releases page.
+          {
+            printf 'Automatic build of `development` @ `%s`.\n\n' "${SHA::7}"
+            printf 'Not a release — see [Releases](https://github.com/%s/releases) for stable builds.\n' "$GITHUB_REPOSITORY"
+            printf '`RecipeLab-dev.apk` always points at the newest development build.\n\n'
+            node tools/dev-notes.js "$VERSION_NAME"
+          } > dev-notes.md
+
           gh release delete dev --yes --cleanup-tag || true
           gh release create dev \
             --prerelease \
             --target "$SHA" \
             --title "v$VERSION_NAME" \
-            --notes "Automatic build of \`development\` @ \`${SHA::7}\`.
-
-          Not a release — see [Releases](https://github.com/${GITHUB_REPOSITORY}/releases) for stable builds.
-          \`RecipeLab-dev.apk\` always points at the newest development build." \
+            --notes-file dev-notes.md \
             "RecipeLab-$VERSION_NAME.apk" RecipeLab-dev.apk RecipeLab-dev.apk.sha256

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ out/
 node_modules/
 *.apk
 *.apk.sha256
+dev-notes.md
 debug.keystore
 *.keystore
 jni/platform/errno.h.updater_only

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -14,7 +14,7 @@ How work moves through this repo. CI enforces most of it, so reading this saves 
 | Branch | Role |
 |---|---|
 | `main` | **Releases only.** Every commit on it is a release, tagged `vX.Y.Z`. Never commit here directly. |
-| `development` | Default branch. Integration. Every push builds a `-dev.N` APK attached to the rolling [`dev` prerelease](https://github.com/voxivoid/recipe-lab-sony-a6000/releases/tag/dev). |
+| `development` | Default branch. Integration. Every push builds a `-dev.N` APK attached to the rolling [`dev` prerelease](https://github.com/voxivoid/recipe-lab-sony-a6000/releases/tag/dev), whose notes list every change since the last release. |
 | work branches | One per issue, cut from `development`, merged back into it. |
 
 ```

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -33,7 +33,9 @@ src/com/voxivoid/recipelab/
 jni/jni.cpp                    Backup_read / Backup_write / Backup_sync_all via OpenMemories-Platform
 jni/platform/                  git submodule: ma1co/OpenMemories-Platform
 res/                           layout, shape drawables, launcher icon
-build.cmd                      full Windows build → RecipeLab.apk (+ copy to dist/)
+build.sh                       the build: ndk-build, aapt, javac, d8, zipalign, apksigner
+build.cmd                      the same seven steps on Windows
+tools/                         version computation, bumping, and the CI gates
 ```
 
 ## Settings slots
@@ -83,15 +85,7 @@ git clone --recursive https://github.com/voxivoid/recipe-lab-sony-a6000.git
 cd recipe-lab-sony-a6000
 ```
 
-**Windows** — `build.cmd`:
-
-```
-set ANDROID_NDK=C:\path\to\android-ndk-r16b      REM optional: JAVA_HOME, ANDROID_SDK, BUILD_TOOLS, PLATFORM_JAR
-build.cmd
-```
-
-**Linux / WSL / macOS** — `build.sh`, the same seven steps and the same APK. This is what CI
-runs, and it is the supported way to build:
+**Linux / WSL / macOS** — `build.sh`. This is what CI runs and the supported way to build:
 
 ```bash
 export JAVA_HOME=$HOME/toolchains/jdk17
@@ -117,7 +111,10 @@ yes | ~/Android/Sdk/cmdline-tools/latest/bin/sdkmanager --licenses >/dev/null
   "build-tools;30.0.3" "platforms;android-28" "ndk;16.1.4479499"
 ```
 
-About 3 GB installed. To sign with the project key rather than a throwaway one, set
+About 3 GB installed. `build.cmd` is the Windows equivalent and is kept in step with
+`build.sh`, but the toolchain it needs is no longer installed on this machine.
+
+To sign with the project key rather than a throwaway one, set
 `ANDROID_KEYSTORE_B64` (`base64 -w0 <keystore>`), `ANDROID_KEYSTORE_PASSWORD`,
 `ANDROID_KEY_ALIAS` and `ANDROID_KEY_PASSWORD` — the same four values CI holds as secrets.
 
@@ -131,15 +128,29 @@ different key **cannot be installed over an existing one** — the camera would 
 CI therefore signs with the project key, held as the `ANDROID_KEYSTORE_B64` repo secret; set the same four
 `ANDROID_KEYSTORE_*` variables locally if you need a build that updates an existing install in place.
 
-### Installing on the camera from WSL
+### Installing on the camera
 
-WSL2 has no USB stack of its own, so the camera is not visible until the device is forwarded
-in. `~/code/pmca-scripts/setup-usb-wsl.sh` does the Linux half (usbip tools, the `054c` udev
-rule, pyusb); the Windows half is `usbipd-win`, installed once from an Administrator
-PowerShell, then `usbipd attach --wsl --busid <id>` each time the camera is plugged in.
+**Build in WSL, install from Windows.** WSL2 is a VM with no USB controller, so the camera is
+only reachable from the Windows side. Everything else — building, dumps, git, releases — is
+WSL-native.
 
-This is the one part that cannot live entirely inside WSL — forwarding a USB device requires
-a driver on the Windows side by design.
+```bash
+./build.sh                              # in the repo
+~/code/pmca-scripts/install-to-camera.sh   # copies the APK over and drives Sony-PMCA-RE
+```
+
+The camera must be on, with `Setup → USB Connection` set to **Mass Storage**. The script
+uses the Windows Python at
+`C:\Users\voxiv\AppData\Local\Programs\Python\Python311\python.exe` against the
+Sony-PMCA-RE checkout at `C:\Users\voxiv\pmca\src`; those two are the only things this
+project still needs on Windows.
+
+If you would rather install from inside WSL as well, `~/code/pmca-scripts/setup-usb-wsl.sh`
+sets up the Linux half of USB forwarding (usbip tools, the `054c` udev rule, pyusb). The
+Windows half is `usbipd-win`: `winget install dorssel.usbipd-win` once from an Administrator
+PowerShell, `usbipd bind --busid <id>` once per camera, then `usbipd.exe attach --wsl --busid
+<id>` after each replug. Forwarding a USB device needs a Windows-side driver either way —
+that part cannot be removed.
 
 ## Versioning
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -171,6 +171,7 @@ instead of being refused as a downgrade.
 | `tools/version.sh` | computes `VERSION_NAME` / `VERSION_CODE` for a build; sourced by `build.sh` |
 | `tools/bump-version.sh <x.y.z>` | opens the next cycle — the only way a version is ever typed |
 | `tools/check-version.sh` | CI gate: manifest is consistent and no version mirror has crept back in |
+| `tools/dev-notes.js <version>` | prints the notes for a dev build from the commits since the last `v*` tag, using the same semantic-release generator and preset as a release |
 
 A build never mutates the checked-in manifest; it writes `out/AndroidManifest.xml` and points `aapt` there.
 

--- a/tools/dev-notes.js
+++ b/tools/dev-notes.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+// Prints the release notes for a development build, e.g.
+//
+//   node tools/dev-notes.js 1.2.0-dev.9
+//
+// The notes cover every commit since the last v* tag and are produced by the same
+// @semantic-release/release-notes-generator and preset config that write the notes on a
+// real release (see .releaserc.js), so a dev prerelease reads exactly like a release.
+//
+// Needs: npm ci. Used by .github/workflows/dev-build.yml.
+import { execFileSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { generateNotes } from '@semantic-release/release-notes-generator';
+import config from '../.releaserc.js';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const git = (...args) => execFileSync('git', args, { cwd: ROOT, encoding: 'utf8' }).trim();
+// git describe exits non-zero when nothing matches, which is the first-release case.
+const gitOrEmpty = (...args) => {
+  try {
+    return execFileSync('git', args, { cwd: ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+  } catch {
+    return '';
+  }
+};
+const fail = (message) => {
+  console.error(`dev-notes: ${message}`);
+  process.exit(1);
+};
+
+const version = process.argv[2] || process.env.VERSION_NAME;
+if (!version) fail('no version given (argv[2] or VERSION_NAME), e.g. 1.2.0-dev.9');
+
+// The rolling `dev` tag is not a release, hence the v* match.
+const from = gitOrEmpty('describe', '--tags', '--abbrev=0', '--match', 'v*');
+const to = git('rev-parse', 'HEAD');
+
+const generator = config.plugins.find(
+  (plugin) => (Array.isArray(plugin) ? plugin[0] : plugin) === '@semantic-release/release-notes-generator'
+);
+if (!generator) fail('.releaserc.js has no @semantic-release/release-notes-generator plugin');
+
+// %x1f separates the fields of a commit, %x1e the commits.
+const commits = git('log', '--format=%H%x1f%B%x1f%cI%x1e', ...(from ? [`${from}..${to}`] : [to]))
+  .split('\x1e')
+  .map((record) => record.trim())
+  .filter(Boolean)
+  .map((record) => {
+    const [hash, message, committerDate] = record.split('\x1f');
+    return { hash, message: message.trim(), gitTags: '', committerDate: new Date(committerDate) };
+  });
+
+const notes = await generateNotes(Array.isArray(generator) ? generator[1] : {}, {
+  cwd: ROOT,
+  env: process.env,
+  options: { repositoryUrl: git('remote', 'get-url', 'origin') },
+  // No tag yet for what is being built: the compare link points at the commit instead.
+  lastRelease: from ? { gitTag: from, version: from.replace(/^v/, '') } : {},
+  nextRelease: { version, gitTag: to, channel: 'dev' },
+  commits,
+  logger: { log: () => {}, error: () => {} },
+});
+
+process.stdout.write(`${notes.trim()}\n`);


### PR DESCRIPTION
Closes #8

The rolling `dev` prerelease carried only "Automatic build of `development` @ `sha`", so there was no way to see what a development APK contained without reading the log.

## What changed

- `tools/dev-notes.js` — prints the notes for the commits since the last `v*` tag by calling `@semantic-release/release-notes-generator` directly with the plugin config read out of `.releaserc.js`. Same generator, same `presetConfig` → a dev build reads exactly like a release: same sections (New / Fixed / Performance / Refactor / Documentation), same hidden types (`ci`, `chore`, `test`), same `⚠ BREAKING CHANGES` block.
- `dev-build.yml` — keeps the existing "not a release" preamble, appends the notes, publishes with `--notes-file`. No extra CI cost: `npm ci` already runs for `tools/next-version.sh`.
- Docs: tools table in `DEVELOPMENT.md`, branch table in `CONTRIBUTING.md`. `dev-notes.md` ignored.

Nothing about the version model, the `dev` tag, the stable `RecipeLab-dev.apk` URL or the release pipeline changes.

## Rejected alternatives

- **Scraping `semantic-release --dry-run`** — its logger flattens the heading to `## 1.1.0 (url)` and indents every bullet four spaces. Lossy.
- **A native prerelease branch** (`{ name: 'development', prerelease: 'dev' }`) — would tag and commit `chore(release)` on every push, put a `-dev` suffix in the manifest (breaks `check-version.sh`) and kill the rolling `dev` URL.

## Testing

Exercised in a throwaway worktree against synthetic commits of every type:

| case | result |
|---|---|
| all types incl. `feat!`, hidden `ci`/`chore`/`test` | correct sections and order, breaking-change block present |
| backticks / quotes / `&` in subjects | verbatim (`execFileSync`, no shell) |
| `Refs #N` and `Closes #N` footers | rendered as `closes [#N]`, same as a release |
| empty range (tag at HEAD) | header only, exit 0 |
| no version argument | `dev-notes: no version given …`, exit 1 |
| `VERSION_NAME` env instead of argv | works |
| run from another cwd | works, paths anchored to the script like `tools/version.sh` |
| no `v*` tag at all | full history, no compare link, no stderr noise |
| rolling `dev` tag present | ignored (`--match 'v*'`) |

The publish itself is only exercised by a real run on `development` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)