### PR TITLE
docs: require PR branches to be up to date before merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,9 @@ The rules below are the ones that break things when ignored.
 - There must be a GitHub issue first; its number goes in the branch name.
 - **Never merge a PR yourself.** Every PR needs an approving review from a code owner; open it
   and leave the merge to a human.
+- **Rebase onto `development` before asking for a merge.** Required checks are strict: a PR whose base
+  has moved on is not mergeable until its checks have run against the tip. `git fetch origin && git rebase
+  origin/development`, then `git push --force-with-lease`.
 - `hotfix/<x.y.z>` off `main`. There is no `release/*` branch — **create-release** merges `development`
   into `main` itself.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -102,7 +102,19 @@ exactly this reason.
 **Every PR needs an approving review from a code owner** ([.github/CODEOWNERS](../.github/CODEOWNERS))
 before it can merge, and review threads must be resolved.
 
-Required checks: `build`, `version-consistency`, `commit-lint`, `pr-title`.
+Required checks: `build`, `version-consistency`, `commit-lint`, `pr-title`. They are **strict**: the checks
+have to have run with `development` at its current tip, so a PR that has fallen behind cannot merge until it
+is brought up to date. Rebase it — that keeps the branch a clean series on top of `development` and keeps the
+squashed commit honest:
+
+```sh
+git fetch origin
+git rebase origin/development
+git push --force-with-lease
+```
+
+GitHub's **Update branch** button does the same job by merging `development` in; it is fine when a rebase
+would be painful, since the merge only ever squashes down to one commit anyway.
 
 > GitHub does not let you approve your own pull request. While `@voxivoid` is the only code
 > owner, their own PRs cannot be approved by anyone else and have to be merged using the


### PR DESCRIPTION
Closes #10

## What changed

Repo config (applied via the API, not in the tree):

- Ruleset `development-protection` → `strict_required_status_checks_policy: true`. A PR now has to have run
  `build`, `version-consistency`, `commit-lint` and `pr-title` against the current tip of `development`;
  a stale branch is blocked until it is rebased or updated.
- Repo setting `allow_update_branch: true`, so the **Update branch** button appears on a stale PR.

Docs in this diff record the rule and the `git fetch && git rebase origin/development && git push
--force-with-lease` flow, in `CLAUDE.md` and `docs/CONTRIBUTING.md`.

## Notes

GitHub has no setting that forces the *rebase* specifically — strict checks force "up to date", and the
docs point at rebase as the way to get there. Merge method on this branch stays squash-only, so either way
the branch lands as one commit.

## Testing

Docs + repo settings only; no camera-facing change. The ruleset now reads back with
`strict_required_status_checks_policy: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)