### PR TITLE
docs: add a camera compatibility section to the README

### DIFF
--- a/.claude/skills/commit-and-pr/SKILL.md
+++ b/.claude/skills/commit-and-pr/SKILL.md
@@ -209,7 +209,7 @@ gh issue edit <issue> --add-label "needs-on-camera-verification"
 ```
 
 The install path for a PR build is the workflow artifact, or `RecipeLab-dev.apk` from the
-rolling [`dev` prerelease](https://github.com/voxivoid/recipe-lab-sony-a6000/releases/tag/dev)
+rolling [`dev` prerelease](https://github.com/voxivoid/recipe-lab-sony-pmca/releases/tag/dev)
 once the change is on `development`.
 
 ### 10. Check CI

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,12 +2,20 @@ name: Bug report
 description: Something in the app misbehaves on the camera
 labels: ["type: fix", "status: needs-triage"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Recipe Lab runs on any Sony body that takes PlayMemories camera apps. It was developed on an **A6000**, and
+        the settings IDs come from that body — so on another camera a wrong value or a missing control is expected
+        rather than a bug. If that is what you are seeing, the
+        [compatibility report](https://github.com/voxivoid/recipe-lab-sony-a6000/issues/new?template=compatibility_report.yml)
+        is the better form.
   - type: input
     id: camera
     attributes:
       label: Camera body
-      description: The app is built for the A6000, but other PMCA bodies turn up.
-      value: Sony A6000
+      description: Model name and code, if you know it.
+      placeholder: "Sony A6000 (ILCE-6000)"
     validations: { required: true }
   - type: input
     id: firmware

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,7 @@ body:
         Recipe Lab runs on any Sony body that takes PlayMemories camera apps. It was developed on an **A6000**, and
         the settings IDs come from that body — so on another camera a wrong value or a missing control is expected
         rather than a bug. If that is what you are seeing, the
-        [compatibility report](https://github.com/voxivoid/recipe-lab-sony-a6000/issues/new?template=compatibility_report.yml)
+        [compatibility report](https://github.com/voxivoid/recipe-lab-sony-pmca/issues/new?template=compatibility_report.yml)
         is the better form.
   - type: input
     id: camera

--- a/.github/ISSUE_TEMPLATE/compatibility_report.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility_report.yml
@@ -1,0 +1,90 @@
+name: Compatibility report
+description: Tell us how Recipe Lab behaved on a camera other than the A6000
+labels: ["type: docs", "status: needs-triage"]
+title: "compat: <camera model>"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Recipe Lab has no model check in it, so it installs on any body that runs PlayMemories camera apps — but the
+        settings IDs were reverse engineered on an A6000 and may sit elsewhere on your camera. This report is what
+        moves a row in the [compatibility table](https://github.com/voxivoid/recipe-lab-sony-a6000#compatibility)
+        from ❔ to ✅.
+
+        **A report that it failed is as useful as one that it worked.** Please file it either way.
+  - type: input
+    id: camera
+    attributes:
+      label: Camera body
+      placeholder: "Sony A5100 (ILCE-5100)"
+    validations: { required: true }
+  - type: input
+    id: firmware
+    attributes:
+      label: Camera firmware version
+      description: MENU → Setup → Version
+      placeholder: "3.10"
+    validations: { required: true }
+  - type: input
+    id: version
+    attributes:
+      label: Recipe Lab version
+      placeholder: "1.1.0 / dev"
+    validations: { required: true }
+  - type: dropdown
+    id: installed
+    attributes:
+      label: Did it install?
+      options:
+        - "Yes"
+        - "No — the installer failed"
+        - "No — the camera has no Application menu"
+    validations: { required: true }
+  - type: dropdown
+    id: stored
+    attributes:
+      label: Did storing a recipe work?
+      description: Pick a recipe, press the centre button, and see what the app says.
+      options:
+        - "Yes — the app confirmed it was stored"
+        - "No — the app reported an error"
+        - "Did not get that far"
+    validations: { required: true }
+  - type: dropdown
+    id: powercycle
+    attributes:
+      label: Did the look survive a power cycle?
+      description: Turn the camera off and on, close the app, take a picture. A look that vanishes after a power cycle was never stored — this is the question the table turns on.
+      options:
+        - "Yes — still there with the app closed"
+        - "No — it was gone"
+        - "Not tested"
+    validations: { required: true }
+  - type: dropdown
+    id: correct
+    attributes:
+      label: Did the stored settings match the recipe?
+      description: Compare the app's chips (style, saturation, contrast, WB, EV) against your camera menus after storing. A mismatch means the setting IDs differ on your body — the thing we most need to know.
+      options:
+        - "Yes — the menus show what the app showed"
+        - "No — something else changed, or a value landed in the wrong place"
+        - "Not checked"
+    validations: { required: true }
+  - type: textarea
+    id: controls
+    attributes:
+      label: Which controls were missing or behaved differently?
+      description: Some bodies have no Fn or AEL button, a different wheel, or a different menu layout. Say what you could not reach.
+      placeholder: "No Fn button, so the brand list never opened. The wheel scrolled recipes fine."
+  - type: textarea
+    id: notes
+    attributes:
+      label: Anything else
+      description: Badge text, messages shown in the app panel (verbatim), screenshots or photos of the camera screen.
+  - type: checkboxes
+    id: ack
+    attributes:
+      label: Before you file
+      options:
+        - label: I understand this app was built and tested on an A6000, and that trying it on another body is at my own risk.
+          required: true

--- a/.github/ISSUE_TEMPLATE/compatibility_report.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility_report.yml
@@ -1,5 +1,5 @@
 name: Compatibility report
-description: Tell us how Recipe Lab behaved on a camera other than the A6000
+description: Tell us how Recipe Lab behaved on your PlayMemories camera
 labels: ["type: docs", "status: needs-triage"]
 title: "compat: <camera model>"
 body:
@@ -9,7 +9,7 @@ body:
         Recipe Lab has no model check in it, so it installs on any body that runs PlayMemories camera apps — but the
         settings IDs were reverse engineered on an A6000 and may sit elsewhere on your camera. This report is what
         moves a row in the [compatibility table](https://github.com/voxivoid/recipe-lab-sony-a6000#compatibility)
-        from ❔ to ✅.
+        from ❔ to ✅, or adds a body the table does not list yet.
 
         **A report that it failed is as useful as one that it worked.** Please file it either way.
   - type: input

--- a/.github/ISSUE_TEMPLATE/compatibility_report.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility_report.yml
@@ -8,7 +8,7 @@ body:
       value: |
         Recipe Lab has no model check in it, so it installs on any body that runs PlayMemories camera apps — but the
         settings IDs were reverse engineered on an A6000 and may sit elsewhere on your camera. This report is what
-        moves a row in the [compatibility table](https://github.com/voxivoid/recipe-lab-sony-a6000#compatibility)
+        moves a row in the [compatibility table](https://github.com/voxivoid/recipe-lab-sony-pmca#compatibility)
         from ❔ to ✅, or adds a body the table does not list yet.
 
         **A report that it failed is as useful as one that it worked.** Please file it either way.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://github.com/ma1co/Sony-PMCA-RE/issues
     about: Install and USB problems belong to Sony-PMCA-RE, which is what puts apps on the camera — not to Recipe Lab.
   - name: Questions and recipe discussion
-    url: https://github.com/voxivoid/recipe-lab-sony-a6000/discussions
+    url: https://github.com/voxivoid/recipe-lab-sony-pmca/discussions
     about: Ask anything that is not a bug report.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,12 @@ name: Feature request
 description: Suggest a change to the app itself
 labels: ["type: feat", "status: needs-triage"]
 body:
+  - type: input
+    id: camera
+    attributes:
+      label: Which camera do you use?
+      description: Optional, but it matters — controls and settings differ across PlayMemories bodies.
+      placeholder: "Sony A5100 (ILCE-5100)"
   - type: textarea
     id: problem
     attributes:
@@ -12,11 +18,14 @@ body:
     id: proposal
     attributes:
       label: What should it do instead?
-      description: If it involves camera controls, say which key or dial — the app only has the wheel, top dial, centre, Fn, C1, AEL, trash and MENU.
+      description: >
+        If it involves camera controls, say which key or dial. On an A6000 the app has the wheel, top dial, four-way,
+        centre, Fn, C1, AEL, trash and MENU — but not every PlayMemories body has all of those (an A5100 has no Fn and
+        no AEL), so anything that hangs off one of those keys needs a route that works without it.
     validations: { required: true }
   - type: dropdown
     id: scope
     attributes:
       label: Which part of the app?
-      options: [ui, input, browser, recipes, tools, build, "not sure"]
+      options: [ui, input, browser, recipes, tools, build, "other camera bodies", "not sure"]
     validations: { required: true }

--- a/.github/ISSUE_TEMPLATE/recipe_request.yml
+++ b/.github/ISSUE_TEMPLATE/recipe_request.yml
@@ -5,10 +5,12 @@ body:
   - type: markdown
     attributes:
       value: |
-        The A6000 has no Picture Profile menu and **cannot store tone curves**. Every recipe is built only
-        from what this body can keep: Creative Style, saturation, contrast, sharpness, white balance,
+        These cameras have no Picture Profile menu and **cannot store tone curves**. Every recipe is built
+        only from what they can keep: Creative Style, saturation, contrast, sharpness, white balance,
         exposure bias, Picture Effect and one hidden colour setting. Recipes here are approximations of a
         look, never copies of another maker's colour science.
+
+        Values are derived on an **A6000**, which is the body the recipes are judged on.
   - type: input
     id: look
     attributes:
@@ -31,5 +33,5 @@ body:
     attributes:
       label: Acknowledgement
       options:
-        - label: I understand this body cannot store tone curves, so the result will be an approximation.
+        - label: I understand these cameras cannot store tone curves, so the result will be an approximation.
           required: true

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 <p align="center">
   Film simulations and camera looks for the <b>Sony A6000</b>, stored in the camera itself.<br>
   <sub>
-    <img src="https://img.shields.io/github/v/release/voxivoid/recipe-lab-sony-a6000?label=version" alt="version"> ·
-    <a href="https://github.com/voxivoid/recipe-lab-sony-a6000/releases/latest/download/RecipeLab.apk">Download the app</a>
+    <img src="https://img.shields.io/github/v/release/voxivoid/recipe-lab-sony-pmca?label=version" alt="version"> ·
+    <a href="https://github.com/voxivoid/recipe-lab-sony-pmca/releases/latest/download/RecipeLab.apk">Download the app</a>
   </sub>
 </p>
 
@@ -77,7 +77,7 @@ The catch: the setting IDs were found on an A6000 and may sit elsewhere on anoth
 wrong place. A camera gets a ✅ only once someone has stored a recipe on it and power-cycled the camera.
 
 Tried one? File a
-[compatibility report](https://github.com/voxivoid/recipe-lab-sony-a6000/issues/new?template=compatibility_report.yml).
+[compatibility report](https://github.com/voxivoid/recipe-lab-sony-pmca/issues/new?template=compatibility_report.yml).
 Failures are as useful as successes.
 
 ### Cameras that run PlayMemories apps
@@ -155,9 +155,9 @@ Sony's own app store did before it closed.
   pip install -r requirements.txt
   ```
 
-**2. Download the app:** [`RecipeLab.apk`](https://github.com/voxivoid/recipe-lab-sony-a6000/releases/latest/download/RecipeLab.apk)
+**2. Download the app:** [`RecipeLab.apk`](https://github.com/voxivoid/recipe-lab-sony-pmca/releases/latest/download/RecipeLab.apk)
 — that link always serves the newest release, so it is the one to use. The
-[releases page](https://github.com/voxivoid/recipe-lab-sony-a6000/releases) has older versions and the
+[releases page](https://github.com/voxivoid/recipe-lab-sony-pmca/releases) has older versions and the
 version-stamped copies.
 
 **3. Prepare the camera.** Battery charged, memory card inside. In the camera menu go to
@@ -263,7 +263,7 @@ The common questions — RAW files, damage, LUTs, newer bodies — are in the **
 | Badge says **PROTECTED** | The camera's settings store is write-protected. Install [OpenMemories-Tweak](https://github.com/ma1co/OpenMemories-Tweak), turn off *Backup protection*, try again |
 | Look not applied after storing | Turn the camera off and on |
 | `no live preview: ...` in the panel | Something else is holding the camera; close and reopen the app |
-| Text shows `Â·` | Old build; install the APK from the [latest release](https://github.com/voxivoid/recipe-lab-sony-a6000/releases/latest) |
+| Text shows `Â·` | Old build; install the APK from the [latest release](https://github.com/voxivoid/recipe-lab-sony-pmca/releases/latest) |
 
 ## For developers
 

--- a/README.md
+++ b/README.md
@@ -87,35 +87,35 @@ just as useful as reports that it worked.
 
 ✅ someone has run it on that body · ❔ app-capable, nobody has reported back yet
 
-| camera | model code | status |
-|---|---|---|
-| **A6000** | ILCE-6000 | ✅ built and tested on it, firmware 3.21 |
-| **A6500** | ILCE-6500 | ✅ installs, stores, survives a power cycle — but the badge reads **PROTECTED** where the A6000 says ACTIVE |
-| **A5100** | ILCE-5100 | ✅ works; the body has no **Fn** or **AEL** button, so the brand list and the clean-preview toggle are out of reach — the wheel still scrolls every recipe |
-| **A7 II** | ILCE-7M2 | ✅ reported working |
-| A6300 | ILCE-6300 | ❔ |
-| A5000 | ILCE-5000 | ❔ |
-| A7 | ILCE-7 | ❔ |
-| A7R | ILCE-7R | ❔ |
-| A7S | ILCE-7S | ❔ |
-| A7R II | ILCE-7RM2 | ❔ |
-| A7S II | ILCE-7SM2 | ❔ |
-| NEX-5R | NEX-5R | ❔ |
-| NEX-5T | NEX-5T | ❔ |
-| NEX-6 | NEX-6 | ❔ menus differ a lot from the A6000 generation |
-| A68 | ILCA-68 | ❔ |
-| A77 II | ILCA-77M2 | ❔ |
-| A99 II | ILCA-99M2 | ❔ |
-| RX100 III | DSC-RX100M3 | ❔ |
-| RX100 IV | DSC-RX100M4 | ❔ |
-| RX100 V | DSC-RX100M5 | ❔ |
-| RX1R II | DSC-RX1RM2 | ❔ |
-| RX10 II | DSC-RX10M2 | ❔ |
-| RX10 III | DSC-RX10M3 | ❔ |
-| HX60 / HX60V | DSC-HX60 | ❔ |
-| HX90 / HX90V | DSC-HX90 | ❔ |
-| HX400 / HX400V | DSC-HX400 | ❔ |
-| WX500 | DSC-WX500 | ❔ |
+| camera | model code | status | comment |
+|---|---|---|---|
+| **A6000** | ILCE-6000 | ✅ | built and tested on it, firmware 3.21 |
+| **A6500** | ILCE-6500 | ✅ | installs, stores, survives a power cycle — but the badge reads **PROTECTED** where the A6000 says ACTIVE |
+| **A5100** | ILCE-5100 | ✅ | works, and the wheel scrolls every recipe — but the body has no **Fn** or **AEL** button, so the brand list and the clean-preview toggle are out of reach |
+| **A7 II** | ILCE-7M2 | ✅ | reported working |
+| A6300 | ILCE-6300 | ❔ | same generation as the A6000; the most likely of these to behave identically |
+| A5000 | ILCE-5000 | ❔ | as with the A5100, expect no **Fn** or **AEL** button |
+| A7 | ILCE-7 | ❔ |  |
+| A7R | ILCE-7R | ❔ |  |
+| A7S | ILCE-7S | ❔ |  |
+| A7R II | ILCE-7RM2 | ❔ |  |
+| A7S II | ILCE-7SM2 | ❔ |  |
+| NEX-5R | NEX-5R | ❔ | oldest app-capable generation |
+| NEX-5T | NEX-5T | ❔ | oldest app-capable generation |
+| NEX-6 | NEX-6 | ❔ | menus differ a lot from the A6000 generation, so the settings are the least likely to sit in the same place |
+| A68 | ILCA-68 | ❔ | A-mount; not in the installer's device table either, so even the install is untested |
+| A77 II | ILCA-77M2 | ❔ | A-mount |
+| A99 II | ILCA-99M2 | ❔ | A-mount |
+| RX100 III | DSC-RX100M3 | ❔ |  |
+| RX100 IV | DSC-RX100M4 | ❔ |  |
+| RX100 V | DSC-RX100M5 | ❔ |  |
+| RX1R II | DSC-RX1RM2 | ❔ |  |
+| RX10 II | DSC-RX10M2 | ❔ |  |
+| RX10 III | DSC-RX10M3 | ❔ |  |
+| HX60 / HX60V | DSC-HX60 | ❔ | compact; no control wheel of the kind the app is driven with |
+| HX90 / HX90V | DSC-HX90 | ❔ | compact; no control wheel of the kind the app is driven with |
+| HX400 / HX400V | DSC-HX400 | ❔ | compact; no control wheel of the kind the app is driven with |
+| WX500 | DSC-WX500 | ❔ | compact; no control wheel of the kind the app is driven with |
 
 Two more with an asterisk: the **RX100 II** (DSC-RX100M2) and the original **RX10** were sold with Sony's app store,
 but neither appears in the installer's device table, so whether `Sony-PMCA-RE` can put an app on them is untested.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - [Installing](#installing)
 - [Using it](#using-it)
 - [What it changes](#what-it-changes)
-- [Undoing it, and uninstalling](#undoing-it-and-uninstalling)
+- [Uninstalling](#uninstalling)
 - [Troubleshooting](#troubleshooting)
 - [FAQ](docs/FAQ.md)
 - [For developers](#for-developers)
@@ -225,7 +225,7 @@ any time. The app also reopens on the recipe you last selected. It does not modi
 camera's firmware or operating system and needs no unlocking or "jailbreak". Installing it uses the same mechanism
 Sony used for its own downloadable apps.
 
-## Undoing it, and uninstalling
+## Uninstalling
 
 **Is it permanent?** The look stays until you change it — on purpose, that is what makes it work in every mode
 without the app. It is not permanent in the sense of damage. Undo it any time, three ways:

--- a/README.md
+++ b/README.md
@@ -186,7 +186,8 @@ Open **Recipe Lab** from the Application List. You get the live image with a pan
 
 | key | what it does |
 |---|---|
-| **wheel** | scroll recipes. The live image changes at once — that is what the camera will write |
+| **wheel** | scroll recipes, from anywhere — the live image changes at once, and that is what the camera will write |
+| **left / right**, **top dial** | scroll recipes too, but only on the recipe line; on the chip row they walk the chips |
 | **Fn** | open the brand list. Brands left, recipes right; left / right switches column (the active one is amber), wheel or up / down scrolls, centre picks |
 | **centre** | store the recipe you are looking at. A message confirms it |
 | **AEL** | hide the panel — once for a small label, twice for nothing. The wheel still works |
@@ -199,8 +200,8 @@ Open **Recipe Lab** from the Application List. You get the live image with a pan
 Then **turn the camera off and on**. The look is now the camera's default in every mode — P, A, S, M, movie — with
 the app closed, and the app reopens on that recipe.
 
-**The chips.** In the chip row, left / right walks the chips, **centre** focuses one (it turns amber), up / down
-changes its value, **centre** leaves it. A recipe only shows the chips it uses: **CS** recipes show style,
+**The chips.** In the chip row, **left / right** walks the chips, **centre** focuses one (it turns amber),
+**up / down** changes its value, **centre** leaves it. The wheel keeps changing recipes throughout. A recipe only shows the chips it uses: **CS** recipes show style,
 saturation, contrast, sharpness and matrix; **PE** recipes show the effect and its sub-setting. Quality, white
 balance, EV and DRO are always there. The legend at the bottom of the screen follows whatever you are doing.
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@
 - [Compatibility](#compatibility)
 - [Installing](#installing)
 - [Using it](#using-it)
-- [What it changes — and how to undo it](#what-it-changes--and-how-to-undo-it)
+- [What it changes](#what-it-changes)
+- [Undoing it, and uninstalling](#undoing-it-and-uninstalling)
 - [Troubleshooting](#troubleshooting)
+- [FAQ](docs/FAQ.md)
 - [For developers](#for-developers)
 - [Credits](#credits)
 
@@ -76,8 +78,10 @@ What nobody can promise from a build is that the *setting IDs* are the same on a
 different slot, or in none. So a camera only gets a ✅ here once someone has run the app on it, stored a recipe and
 **power-cycled** the camera — a look that disappears after a power cycle was never stored.
 
-The ✅ rows below come from people who installed it and said what happened. **Tried it?** Open an issue with the model, the firmware version and whether the look survived a power cycle, and the
-table below gets updated.
+The ✅ rows below come from people who installed it and said what happened. **Tried it on any body?** Please file a
+[compatibility report](https://github.com/voxivoid/recipe-lab-sony-a6000/issues/new?template=compatibility_report.yml)
+— model, firmware, whether the look survived a power cycle — and the table gets updated. Reports that it *failed* are
+just as useful as reports that it worked.
 
 ### Cameras that run PlayMemories apps
 
@@ -145,9 +149,13 @@ Linux).
 **1. Get the installer tool.** It is called *Sony-PMCA-RE*, made by ma1co. It puts apps on Sony cameras the same way
 Sony's own app store did before it closed.
 
-- *Windows, easiest:* download `pmca-gui.exe` from the
+- *Windows:* download `pmca-gui.exe` from the
   [releases page](https://github.com/ma1co/Sony-PMCA-RE/releases). Nothing to install, just run it.
-- *Mac, Linux, or Windows without the GUI:* install Python 3, then in a terminal:
+- *macOS:* the same releases page has a macOS build of the GUI. It is less tested than the Windows one, so if it
+  misbehaves use the Python route below. Sony's own camera driver has to be present, and anything that grabs USB
+  devices in the background — Photos, Dropbox, Google Drive — has to be closed, or it will take the camera before the
+  installer can.
+- *Linux, or any platform without the binary:* Python 3 and libusb, then in a terminal:
 
   ```
   git clone https://github.com/ma1co/Sony-PMCA-RE.git
@@ -174,10 +182,22 @@ The camera screen should say *USB Mode*.
   ```
 
 The camera will flicker, go black and switch modes a couple of times on its own. That is normal — do not press
-anything. After about a minute the computer prints `Task completed successfully` and the camera is back on its
-shooting screen.
+anything. After about a minute the computer prints `Task completed successfully`.
 
-**5. Unplug.** The app now lives under `MENU → Application → Application List → Recipe Lab`.
+**Go by the computer, not by the camera.** When the installer is done the camera is usually left sitting on its own
+USB screen:
+
+```
+Application Download
+Connecting via USB...
+To change the USB connection mode, disconnect the USB cable from the computer and reconnect.
+```
+
+That looks stuck, and it is not — it is simply where the install leaves the camera. If the computer said
+`Task completed successfully`, the app is on.
+
+**5. Unplug, then turn the camera off and on.** The app now lives under
+`MENU → Application → Application List → Recipe Lab`.
 
 ## Using it
 
@@ -208,7 +228,7 @@ The small badge next to the recipe name tells you where you stand: **ACTIVE** �
 values · **PREVIEW** — you are only looking, press the centre button to keep it · **PROTECTED** — the camera is not
 accepting changes (see [Troubleshooting](#troubleshooting)).
 
-## What it changes — and how to undo it
+## What it changes
 
 **What it actually does.** Recipe Lab sets the same things you could set by hand in the menus — Creative Style with
 its contrast, saturation and sharpness sliders, white balance and its fine-tune, exposure compensation, Picture
@@ -224,6 +244,8 @@ any time. The app also reopens on the recipe you last selected. It does not modi
 camera's firmware or operating system and needs no unlocking or "jailbreak". Installing it uses the same mechanism
 Sony used for its own downloadable apps.
 
+## Undoing it, and uninstalling
+
 **Is it permanent?** The look stays until you change it — on purpose, that is what makes it work in every mode
 without the app. It is not permanent in the sense of damage. Undo it any time, three ways:
 
@@ -231,18 +253,23 @@ without the app. It is not permanent in the sense of damage. Undo it any time, t
 - In the menus: set Creative Style back to *Standard* 0 / 0 / 0 and White Balance to *Auto*.
 - Or use the camera's own `Setup → Setting Reset → Camera Settings Reset`.
 
+**Removing the app.** `MENU → Application → Application Management → Manage and Remove → Recipe Lab`. Uninstalling
+does **not** put the colour settings back — the app only ever wrote what the menus can write, and those values stay
+where they are. So undo the look first, by any of the three ways above, and remove the app after.
+
 **Worth knowing:**
 
 - Some recipes push saturation further than the menu slider goes (the menu allows ±3, the camera accepts more). The
   menu then shows the nearest value it can; if you touch that slider it snaps back to the normal range and the
   recipe loses that extra punch. Re-store from the app if that happens.
 - The preview inside the app is temporary; closing the app removes it. Only what you *stored* stays.
-- Uninstalling the app does **not** put the colour settings back. Undo first (any of the three ways above), then
-  remove it via `MENU → Application → Application Management → Manage and Remove → Recipe Lab`.
 - Built and tested on the A6000 with firmware 3.21. Other Sony bodies of the same generation probably keep these
   settings in the same place, but nobody has checked — compare what the chips show with your menus before storing.
 
 ## Troubleshooting
+
+Answers to the questions people ask most — RAW safety, whether this can damage the camera, LUTs, newer bodies — live
+in the **[FAQ](docs/FAQ.md)**.
 
 | what you see | what to do |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -194,7 +194,6 @@ Open **Recipe Lab** from the Application List. You get the live image with a pan
 | **up / down** | move between the recipe line and the row of value chips |
 | **TRASH** | stage the factory look, then **centre** to store it |
 | **shutter** | take a picture of what you are previewing |
-| **C1** | developer tool: snapshot every setting, press again after a menu change to find which slot it lives in |
 | **MENU** | leave the app |
 
 Then **turn the camera off and on**. The look is now the camera's default in every mode — P, A, S, M, movie — with

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 
 - [What it is](#what-it-is)
 - [The recipes](#the-recipes)
+- [Compatibility](#compatibility)
 - [Installing](#installing)
 - [Using it](#using-it)
 - [What it changes — and how to undo it](#what-it-changes--and-how-to-undo-it)
@@ -64,6 +65,77 @@ curve gets closer than Creative Style can; everything else stays Creative Style 
 Not included, because the camera simply cannot do them: log profiles (S-Log, V-Log, Blackmagic Film, Cinelike D) and
 tinted black & white (selenium, cyanotype). Sony's camcorder *Cinematone* gamma exists in the firmware but the A6000's
 camera layer neither lists nor accepts it, so that door is closed too.
+
+## Compatibility
+
+Recipe Lab has no model check in it. It reaches the camera's settings store through ma1co's OpenMemories backup
+driver, and **every Sony body that accepts PlayMemories camera apps has that same store** — so the app should install
+and run on all of them, not only the A6000.
+
+What nobody can promise from a build is that the *setting IDs* are the same on another body. A recipe could land in a
+different slot, or in none. So a camera only gets a ✅ here once someone has run the app on it, stored a recipe and
+**power-cycled** the camera — a look that disappears after a power cycle was never stored.
+
+The ✅ rows below come from people who installed it and said what happened. **Tried it?** Open an issue with the model, the firmware version and whether the look survived a power cycle, and the
+table below gets updated.
+
+### Cameras that run PlayMemories apps
+
+✅ someone has run it on that body · ❔ app-capable, nobody has reported back yet
+
+| camera | model code | status |
+|---|---|---|
+| **A6000** | ILCE-6000 | ✅ built and tested on it, firmware 3.21 |
+| **A6500** | ILCE-6500 | ✅ installs, stores, survives a power cycle — but the badge reads **PROTECTED** where the A6000 says ACTIVE |
+| **A5100** | ILCE-5100 | ✅ works; the body has no **Fn** or **AEL** button, so the brand list and the clean-preview toggle are out of reach — the wheel still scrolls every recipe |
+| **A7 II** | ILCE-7M2 | ✅ reported working |
+| A6300 | ILCE-6300 | ❔ |
+| A5000 | ILCE-5000 | ❔ |
+| A7 | ILCE-7 | ❔ |
+| A7R | ILCE-7R | ❔ |
+| A7S | ILCE-7S | ❔ |
+| A7R II | ILCE-7RM2 | ❔ |
+| A7S II | ILCE-7SM2 | ❔ |
+| NEX-5R | NEX-5R | ❔ |
+| NEX-5T | NEX-5T | ❔ |
+| NEX-6 | NEX-6 | ❔ menus differ a lot from the A6000 generation |
+| A68 | ILCA-68 | ❔ |
+| A77 II | ILCA-77M2 | ❔ |
+| A99 II | ILCA-99M2 | ❔ |
+| RX100 III | DSC-RX100M3 | ❔ |
+| RX100 IV | DSC-RX100M4 | ❔ |
+| RX100 V | DSC-RX100M5 | ❔ |
+| RX1R II | DSC-RX1RM2 | ❔ |
+| RX10 II | DSC-RX10M2 | ❔ |
+| RX10 III | DSC-RX10M3 | ❔ |
+| HX60 / HX60V | DSC-HX60 | ❔ |
+| HX90 / HX90V | DSC-HX90 | ❔ |
+| HX400 / HX400V | DSC-HX400 | ❔ |
+| WX500 | DSC-WX500 | ❔ |
+
+Two more with an asterisk: the **RX100 II** (DSC-RX100M2) and the original **RX10** were sold with Sony's app store,
+but neither appears in the installer's device table, so whether `Sony-PMCA-RE` can put an app on them is untested.
+
+App-capable, but **not** Recipe Lab targets: the QX lens-style cameras (ILCE-QX1, DSC-QX10/QX30/QX100) have no screen
+or control wheel to drive the app with, and the Handycam camcorders (FDR-AX…, HDR-CX/PJ…) and action cams
+(FDR-X…, HDR-AS…) have no Creative Style to write. The app may install; there is nothing useful behind it.
+
+### Cameras that cannot run camera apps at all
+
+Everything Sony has released since the A6500 (late 2016). Their firmware is cryptographically signed, so no app can be
+installed on them by any means — not this one, not Sony's own store, which closed in 2021. There is no workaround and
+none is coming.
+
+| | |
+|---|---|
+| **E-mount, APS-C** | A6100, A6400, A6600, A6700, ZV-E10, ZV-E10 II, FX30 |
+| **E-mount, full frame** | A7 III, A7R III, A7R IV / IVA, A7R V, A7S III, A7C, A7C II, A7CR, A9, A9 II, A9 III, A1, A1 II, ZV-E1, FX3 |
+| **Cyber-shot** | RX100 VA, RX100 VI, RX100 VII, RX10 IV, RX0, RX0 II, HX99, ZV-1, ZV-1F, ZV-1 II |
+
+…and every model launched after those. If your camera is newer than an A6500, it cannot run Recipe Lab.
+
+You may come across a report that it runs on one of these anyway. It cannot: these bodies have no `MENU →
+Application` at all. If that menu is missing on your camera, nothing can be installed on it.
 
 ## Installing
 

--- a/README.md
+++ b/README.md
@@ -182,32 +182,35 @@ is usually left on its own `Application Download / Connecting via USB...` screen
 
 ## Using it
 
-1. Open **Recipe Lab** from the Application List. You see the live image with a panel at the bottom.
-2. **Turn the control wheel** (the ring on the back). Every click is a different recipe and the live image changes
-   immediately — this is exactly how your photos and videos will look.
-3. To jump between brands press **Fn**. A list opens: brands on the left,
-   recipes on the right. Left/right picks which column you are scrolling (the active one is amber), up/down or the
-   wheel scrolls it, the image keeps following. Centre button on a brand jumps into its recipes; centre button on a
-   recipe picks it and closes the list.
-4. To see the image without any text press **AEL**: once for a tiny label, twice for nothing at all. The wheel still
-   works. Press again to bring the panel back.
-5. Like it? Press the **centre button**. A message confirms it was stored.
-6. **Turn the camera off and on.** Done. The look is now the camera's default in every mode — P, A, S, M, movie —
-   with the app closed. Next time you open the app it starts on that recipe.
+Open **Recipe Lab** from the Application List. You get the live image with a panel at the bottom, then:
 
-A few extras:
-
-| | |
+| key | what it does |
 |---|---|
-| **up / down** | moves between the recipe line and the row of value chips. In the chip row, left / right walks the chips; press the centre button to focus one (it turns amber), then up / down changes its value, centre button again leaves it. Only the chips the recipe uses are shown: a **CS** (Creative Style) recipe shows style / saturation / contrast / sharpness / matrix, a **PE** (Picture Effect) recipe shows the effect and its sub-setting instead; quality, white balance, EV and DRO always. The legend at the bottom changes with each state |
-| **C1** | developer tool: snapshot of all settings; press again after changing a menu item to see which slot it lives in |
-| **TRASH** (bin button) | stages the factory look; centre button stores it |
-| **shutter** | takes a picture with whatever you are previewing |
-| **MENU** | leaves the app |
+| **wheel** | scroll recipes. The live image changes at once — that is what the camera will write |
+| **Fn** | open the brand list. Brands left, recipes right; left / right switches column (the active one is amber), wheel or up / down scrolls, centre picks |
+| **centre** | store the recipe you are looking at. A message confirms it |
+| **AEL** | hide the panel — once for a small label, twice for nothing. The wheel still works |
+| **up / down** | move between the recipe line and the row of value chips |
+| **TRASH** | stage the factory look, then **centre** to store it |
+| **shutter** | take a picture of what you are previewing |
+| **C1** | developer tool: snapshot every setting, press again after a menu change to find which slot it lives in |
+| **MENU** | leave the app |
 
-The small badge next to the recipe name tells you where you stand: **ACTIVE** — the camera already has these
-values · **PREVIEW** — you are only looking, press the centre button to keep it · **PROTECTED** — the camera is not
-accepting changes (see [Troubleshooting](#troubleshooting)).
+Then **turn the camera off and on**. The look is now the camera's default in every mode — P, A, S, M, movie — with
+the app closed, and the app reopens on that recipe.
+
+**The chips.** In the chip row, left / right walks the chips, **centre** focuses one (it turns amber), up / down
+changes its value, **centre** leaves it. A recipe only shows the chips it uses: **CS** recipes show style,
+saturation, contrast, sharpness and matrix; **PE** recipes show the effect and its sub-setting. Quality, white
+balance, EV and DRO are always there. The legend at the bottom of the screen follows whatever you are doing.
+
+**The badge** next to the recipe name says where you stand:
+
+| badge | meaning |
+|---|---|
+| **ACTIVE** | the camera already has these values |
+| **PREVIEW** | you are only looking; press **centre** to keep it |
+| **PROTECTED** | the camera is not accepting changes — see [Troubleshooting](#troubleshooting) |
 
 ## What it changes
 

--- a/README.md
+++ b/README.md
@@ -70,18 +70,15 @@ camera layer neither lists nor accepts it, so that door is closed too.
 
 ## Compatibility
 
-Recipe Lab has no model check in it. It reaches the camera's settings store through ma1co's OpenMemories backup
-driver, and **every Sony body that accepts PlayMemories camera apps has that same store** — so the app should install
-and run on all of them, not only the A6000.
+Recipe Lab has no model check in it, and every Sony body that runs PlayMemories apps has the same settings store — so
+it should install and work beyond the A6000.
 
-What nobody can promise from a build is that the *setting IDs* are the same on another body. A recipe could land in a
-different slot, or in none. So a camera only gets a ✅ here once someone has run the app on it, stored a recipe and
-**power-cycled** the camera — a look that disappears after a power cycle was never stored.
+The catch: the setting IDs were found on an A6000 and may sit elsewhere on another body, so a recipe could land in the
+wrong place. A camera gets a ✅ only once someone has stored a recipe on it and power-cycled the camera.
 
-The ✅ rows below come from people who installed it and said what happened. **Tried it on any body?** Please file a
-[compatibility report](https://github.com/voxivoid/recipe-lab-sony-a6000/issues/new?template=compatibility_report.yml)
-— model, firmware, whether the look survived a power cycle — and the table gets updated. Reports that it *failed* are
-just as useful as reports that it worked.
+Tried one? File a
+[compatibility report](https://github.com/voxivoid/recipe-lab-sony-a6000/issues/new?template=compatibility_report.yml).
+Failures are as useful as successes.
 
 ### Cameras that run PlayMemories apps
 
@@ -117,18 +114,17 @@ just as useful as reports that it worked.
 | HX400 / HX400V | DSC-HX400 | ❔ | compact; no control wheel of the kind the app is driven with |
 | WX500 | DSC-WX500 | ❔ | compact; no control wheel of the kind the app is driven with |
 
-Two more with an asterisk: the **RX100 II** (DSC-RX100M2) and the original **RX10** were sold with Sony's app store,
-but neither appears in the installer's device table, so whether `Sony-PMCA-RE` can put an app on them is untested.
+Two more are unclear: the **RX100 II** and the original **RX10** had Sony's app store, but are missing from the
+installer's device table, so even the install is untested.
 
-App-capable, but **not** Recipe Lab targets: the QX lens-style cameras (ILCE-QX1, DSC-QX10/QX30/QX100) have no screen
-or control wheel to drive the app with, and the Handycam camcorders (FDR-AX…, HDR-CX/PJ…) and action cams
-(FDR-X…, HDR-AS…) have no Creative Style to write. The app may install; there is nothing useful behind it.
+App-capable but pointless: the QX lens cameras (ILCE-QX1, DSC-QX10/QX30/QX100), with no screen or wheel to drive the
+app, and the Handycams and action cams, with no Creative Style to write.
 
-### Cameras that cannot run camera apps at all
+### Cameras that cannot run camera apps
 
-Everything Sony has released since the A6500 (late 2016). Their firmware is cryptographically signed, so no app can be
-installed on them by any means — not this one, not Sony's own store, which closed in 2021. There is no workaround and
-none is coming.
+Sony's last app-capable bodies are the ones above, from late 2016 — the A6500 and the A99 II. Everything since has
+signed firmware and no `MENU → Application`, so nothing can be installed on it: not this app, not Sony's own store,
+which closed in 2021.
 
 | | |
 |---|---|
@@ -136,10 +132,8 @@ none is coming.
 | **E-mount, full frame** | A7 III, A7R III, A7R IV / IVA, A7R V, A7S III, A7C, A7C II, A7CR, A9, A9 II, A9 III, A1, A1 II, ZV-E1, FX3 |
 | **Cyber-shot** | RX100 VA, RX100 VI, RX100 VII, RX10 IV, RX0, RX0 II, HX99, ZV-1, ZV-1F, ZV-1 II |
 
-…and every model launched after those. If your camera is newer than an A6500, it cannot run Recipe Lab.
-
-You may come across a report that it runs on one of these anyway. It cannot: these bodies have no `MENU →
-Application` at all. If that menu is missing on your camera, nothing can be installed on it.
+…and everything released since. The menu is the test: no `MENU → Application` on your camera, no app — so reports of
+Recipe Lab running on an A6400 or similar are mistaken.
 
 ## Installing
 
@@ -151,11 +145,9 @@ Sony's own app store did before it closed.
 
 - *Windows:* download `pmca-gui.exe` from the
   [releases page](https://github.com/ma1co/Sony-PMCA-RE/releases). Nothing to install, just run it.
-- *macOS:* the same releases page has a macOS build of the GUI. It is less tested than the Windows one, so if it
-  misbehaves use the Python route below. Sony's own camera driver has to be present, and anything that grabs USB
-  devices in the background — Photos, Dropbox, Google Drive — has to be closed, or it will take the camera before the
-  installer can.
-- *Linux, or any platform without the binary:* Python 3 and libusb, then in a terminal:
+- *macOS:* the same page has a macOS build, less tested than the Windows one. Close anything that holds USB devices —
+  Photos, Dropbox, Google Drive — or it takes the camera first.
+- *Linux, or if the binary misbehaves:* Python 3 and libusb, then in a terminal:
 
   ```
   git clone https://github.com/ma1co/Sony-PMCA-RE.git
@@ -182,19 +174,8 @@ The camera screen should say *USB Mode*.
   ```
 
 The camera will flicker, go black and switch modes a couple of times on its own. That is normal — do not press
-anything. After about a minute the computer prints `Task completed successfully`.
-
-**Go by the computer, not by the camera.** When the installer is done the camera is usually left sitting on its own
-USB screen:
-
-```
-Application Download
-Connecting via USB...
-To change the USB connection mode, disconnect the USB cable from the computer and reconnect.
-```
-
-That looks stuck, and it is not — it is simply where the install leaves the camera. If the computer said
-`Task completed successfully`, the app is on.
+anything. After about a minute the computer prints `Task completed successfully`. **Go by the computer.** The camera
+is usually left on its own `Application Download / Connecting via USB...` screen, which looks stuck and is not.
 
 **5. Unplug, then turn the camera off and on.** The app now lives under
 `MENU → Application → Application List → Recipe Lab`.
@@ -253,9 +234,8 @@ without the app. It is not permanent in the sense of damage. Undo it any time, t
 - In the menus: set Creative Style back to *Standard* 0 / 0 / 0 and White Balance to *Auto*.
 - Or use the camera's own `Setup → Setting Reset → Camera Settings Reset`.
 
-**Removing the app.** `MENU → Application → Application Management → Manage and Remove → Recipe Lab`. Uninstalling
-does **not** put the colour settings back — the app only ever wrote what the menus can write, and those values stay
-where they are. So undo the look first, by any of the three ways above, and remove the app after.
+**Removing the app.** `MENU → Application → Application Management → Manage and Remove → Recipe Lab`. This does
+**not** put the colour settings back, so undo the look first and remove the app after.
 
 **Worth knowing:**
 
@@ -268,8 +248,7 @@ where they are. So undo the look first, by any of the three ways above, and remo
 
 ## Troubleshooting
 
-Answers to the questions people ask most — RAW safety, whether this can damage the camera, LUTs, newer bodies — live
-in the **[FAQ](docs/FAQ.md)**.
+The common questions — RAW files, damage, LUTs, newer bodies — are in the **[FAQ](docs/FAQ.md)**.
 
 | what you see | what to do |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ is usually left on its own `Application Download / Connecting via USB...` screen
    works. Press again to bring the panel back.
 5. Like it? Press the **centre button**. A message confirms it was stored.
 6. **Turn the camera off and on.** Done. The look is now the camera's default in every mode — P, A, S, M, movie —
-   with the app closed.
+   with the app closed. Next time you open the app it starts on that recipe.
 
 A few extras:
 
@@ -211,19 +211,22 @@ accepting changes (see [Troubleshooting](#troubleshooting)).
 
 ## What it changes
 
-**What it actually does.** Recipe Lab sets the same things you could set by hand in the menus — Creative Style with
-its contrast, saturation and sharpness sliders, white balance and its fine-tune, exposure compensation, Picture
-Effect — plus one hidden switch that turns on a richer colour matrix the camera has but never shows. Recipes that
-use a Picture Effect (Retro, Soft High-key, High Contrast Mono) behave like that menu item does: the camera ignores
-Creative Style while it is on, and **it needs Quality = JPEG** — with RAW or RAW+JPEG set, the camera silently drops
-the effect. Quality is therefore handled like this: the **Factory recipe carries your Quality** — it starts as
-whatever the camera is set to, and if you change it there (QUALITY chip or Fn) the app remembers it. Every Creative
-Style recipe uses that same Quality. Picture Effect recipes use it too when it is a JPEG setting, otherwise they use
-JPEG Fine. Whenever storing a recipe would change the camera's Quality the app asks first (`Quality: RAW+JPG → JPG
-Fine — JPEG is needed to apply this recipe`, *Accept* / *Cancel*); Cancel stores nothing. The QUALITY chip changes it
-any time. The app also reopens on the recipe you last selected. It does not modify the
-camera's firmware or operating system and needs no unlocking or "jailbreak". Installing it uses the same mechanism
-Sony used for its own downloadable apps.
+Only camera settings you could set by hand: Creative Style and its saturation, contrast and sharpness sliders, white
+balance and its fine-tune, exposure compensation, DRO, Picture Effect — plus one hidden switch for a richer colour
+matrix the camera has but never shows. No firmware is touched, nothing is unlocked.
+
+**Picture Effect recipes** (marked **PE**) behave like the menu item does: the camera ignores Creative Style while one
+is on, and it only works with **Quality = JPEG** — set to RAW or RAW+JPEG, the camera drops the effect silently.
+
+**Quality** therefore follows you rather than being dictated by a recipe. The Factory recipe starts as whatever the
+camera is set to, and every Creative Style recipe uses that. Change it any time with the `QUALITY` chip. Only when a
+recipe needs JPEG and you are on RAW does the app ask:
+
+```
+Quality: RAW+JPG → JPG Fine — JPEG is needed to apply this recipe
+```
+
+*Cancel* stores nothing.
 
 ## Uninstalling
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -14,7 +14,7 @@ How work moves through this repo. CI enforces most of it, so reading this saves 
 | Branch | Role |
 |---|---|
 | `main` | **Releases only.** Every commit on it is a release, tagged `vX.Y.Z`. Never commit here directly. |
-| `development` | Default branch. Integration. Every push builds a `-dev.N` APK attached to the rolling [`dev` prerelease](https://github.com/voxivoid/recipe-lab-sony-a6000/releases/tag/dev), whose notes list every change since the last release. |
+| `development` | Default branch. Integration. Every push builds a `-dev.N` APK attached to the rolling [`dev` prerelease](https://github.com/voxivoid/recipe-lab-sony-pmca/releases/tag/dev), whose notes list every change since the last release. |
 | work branches | One per issue, cut from `development`, merged back into it. |
 
 ```

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -156,8 +156,8 @@ Toolchain, both platforms: **JDK 17**, Android SDK **build-tools 30.0.3** with a
 that combination is what rules out every later NDK.
 
 ```
-git clone --recursive https://github.com/voxivoid/recipe-lab-sony-a6000.git
-cd recipe-lab-sony-a6000
+git clone --recursive https://github.com/voxivoid/recipe-lab-sony-pmca.git
+cd recipe-lab-sony-pmca
 ```
 
 **Linux / WSL / macOS** — `build.sh`. This is what CI runs and the supported way to build:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -61,6 +61,22 @@ Found by disassembling the camera app's parameter registration in `libObj.so`):
 | Quality: file format | `0x01070013` (+ mirror `0x01070aa9`) | RAW = 1, RAW+JPEG = 2, JPEG = 0 (verified) |
 | Quality: JPEG level | `0x01070014` (+ mirror `0x01070aaa`) | Std = 0, Fine = 1 (verified) |
 
+## Snapshot / diff tool (C1)
+
+How the slots above were found, and how to find the next one. **C1** in the app runs `snapshotOrDiff()`, over every
+id in `res/raw/ids.txt` (each settings entry of 16 bytes or less):
+
+1. **First press** writes `snapshot.bin` into `getFilesDir()` — the current value of every id.
+2. Leave the app, change **one** thing in the camera menus, reopen.
+3. **Second press** re-reads every id, diffs it against the snapshot, shows the changed ones as
+   `id:old>new` (first 14 on screen), appends the same line to `diff.txt` in `getFilesDir()`, and deletes
+   `snapshot.bin` — so the next press starts a fresh snapshot.
+
+Whatever shows up is the slot for the menu item you changed. Change one thing at a time or the diff is useless:
+the camera rewrites unrelated entries on its own, so a second change means guessing which id belongs to what.
+
+Note the toast still says "press Fn again" — the handler is on `K_C1`. The string is wrong, not the binding.
+
 ## Exit rule
 
 The camera writes some live parameters (exposure bias, WB fine-tune) straight back into the settings

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -27,7 +27,7 @@ AndroidManifest.xml            package com.voxivoid.recipelab
 src/com/voxivoid/recipelab/
   MainActivity.java            UI state, key handling, live preview (CameraEx via reflection), store + sync
   Recipes.java                 the 77 recipes, brands, GROUP_START / GROUP_COUNT
-  res/raw/ids.txt              every settings entry of 16 bytes or less, used by the Fn snapshot/diff tool
+  res/raw/ids.txt              every settings entry of 16 bytes or less, used by the C1 snapshot/diff tool
   PickerView.java              Canvas-drawn brand browser
   Legend.java                  Canvas-drawn key icons, fit-to-width (camera font has no symbol glyphs)
   HintBar.java                 legend view under the panel (uses Legend)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -58,7 +58,7 @@ open question, body by body — see [Compatibility](../README.md#compatibility),
 which ones people have confirmed, and which Sony bodies cannot run apps at all.
 
 If you try one, please file a
-[compatibility report](https://github.com/voxivoid/recipe-lab-sony-a6000/issues/new?template=compatibility_report.yml).
+[compatibility report](https://github.com/voxivoid/recipe-lab-sony-pmca/issues/new?template=compatibility_report.yml).
 
 ## My camera is newer than that — is there a version for it?
 
@@ -112,4 +112,4 @@ write.
 
 The [Troubleshooting table](../README.md#troubleshooting) covers the common ones. Install and USB problems belong to
 [Sony-PMCA-RE](https://github.com/ma1co/Sony-PMCA-RE/issues), which is what puts apps on the camera; anything about
-the recipes or the app itself belongs [here](https://github.com/voxivoid/recipe-lab-sony-a6000/issues).
+the recipes or the app itself belongs [here](https://github.com/voxivoid/recipe-lab-sony-pmca/issues).

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -33,7 +33,7 @@ same way Sony's app store did before it closed. No firmware is replaced, nothing
 Recipe Lab then writes only values the menus can already write — Creative Style and its sliders, white balance,
 exposure bias, Picture Effect, DRO, Quality — plus one hidden colour-matrix switch the camera has but never lists.
 Any of it can be undone from the camera's own
-[`Setup → Setting Reset → Camera Settings Reset`](../README.md#undoing-it-and-uninstalling).
+[`Setup → Setting Reset → Camera Settings Reset`](../README.md#uninstalling).
 
 The honest caveat is **other bodies**. The setting IDs were reverse engineered on an A6000, and the same value can
 live in a different slot on a different model — so on an untested body a recipe could land somewhere unintended.
@@ -60,15 +60,14 @@ which ones people have confirmed, and which Sony bodies cannot run apps at all.
 If you try one, please file a
 [compatibility report](https://github.com/voxivoid/recipe-lab-sony-a6000/issues/new?template=compatibility_report.yml).
 
-## My camera is newer than an A6500 — is there a version for it?
+## My camera is newer than that — is there a version for it?
 
-There cannot be. Sony dropped the on-camera app platform after 2016: every body since — A6100, A6400, A6600, A6700,
-A7 III onwards, A9, A1, the ZV and FX cameras, RX100 VA and later — has cryptographically signed firmware and no
-`MENU → Application` at all. Nothing can be installed on them, by this project or anyone else. Those cameras do have
-Picture Profiles and Creative Looks in the menus, which is the feature Recipe Lab exists to make up for.
+There cannot be. Sony's last app-capable bodies are from late 2016, the A6500 and the A99 II. Everything since —
+A6100, A6400, A6600, A6700, A7 III onwards, A9, A1, the ZV and FX cameras, RX100 VA and later — has signed firmware
+and no `MENU → Application`, so nothing can be installed on it by anyone.
 
-You may come across a report of Recipe Lab running on one of these. It cannot: check for the Application menu, and if
-it is missing, no app is installed.
+Those cameras do have Picture Profiles and Creative Looks in the menus, which is the feature Recipe Lab exists to make
+up for on the A6000.
 
 ## Can I make my own recipes and save them?
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,116 @@
+# FAQ
+
+The questions people actually ask. For the step-by-step install, the recipe list and the undo instructions, see the
+[README](../README.md).
+
+---
+
+## Will this touch my RAW files?
+
+No. Recipe Lab sets the same camera settings you could set by hand in the menus, and the camera treats them the way
+it always has: the look is baked into the **JPEG**, the RAW stays a RAW. Shoot RAW+JPEG and you get a processed JPEG
+next to an untouched raw file, exactly as before.
+
+The one catch is the recipes marked **PE**, which are built on a Picture Effect. The A6000 refuses to apply a Picture
+Effect unless Quality is a JPEG setting — with RAW or RAW+JPEG selected it silently drops the effect. So when storing
+one of those would change your Quality, the app asks first:
+
+```
+Quality: RAW+JPG → JPG Fine — JPEG is needed to apply this recipe
+```
+
+*Cancel* stores nothing and leaves your Quality alone. Pick a Creative Style recipe instead and you keep shooting RAW.
+
+Going back is just as plain: every Creative Style recipe uses whatever Quality the camera is set to, so switch Quality
+back to RAW (`QUALITY` chip in the app, or the normal menu) and RAW files come back. Nothing about the switch is
+one-way.
+
+## Can this damage or brick my camera?
+
+Installing an app is the mechanism Sony itself shipped: the camera has an app menu, and `Sony-PMCA-RE` talks to it the
+same way Sony's app store did before it closed. No firmware is replaced, nothing is unlocked, no "jailbreak".
+
+Recipe Lab then writes only values the menus can already write — Creative Style and its sliders, white balance,
+exposure bias, Picture Effect, DRO, Quality — plus one hidden colour-matrix switch the camera has but never lists.
+Any of it can be undone from the camera's own
+[`Setup → Setting Reset → Camera Settings Reset`](../README.md#undoing-it-and-uninstalling).
+
+The honest caveat is **other bodies**. The setting IDs were reverse engineered on an A6000, and the same value can
+live in a different slot on a different model — so on an untested body a recipe could land somewhere unintended.
+That is why the [compatibility table](../README.md#compatibility) only marks a camera ✅ once someone has actually
+run it. If your body is a ❔, expect to check the app's chips against your menus before storing anything.
+
+## Do I need Wi-Fi, a Sony account, or the app store?
+
+No. Sony's PlayMemories app store closed in 2021 and none of this goes near it. The app arrives over the USB cable
+from your computer.
+
+## Does the look stay with the app closed?
+
+Yes — that is the whole point. Storing a recipe writes it into the camera's settings, so it applies in every mode,
+photo and video, with Recipe Lab closed and after a power cycle. What the app shows *before* you store is only a live
+preview, and that disappears when you leave the app.
+
+## Will it work on my camera?
+
+If your camera can run PlayMemories camera apps, it should install. Whether the stored values land correctly is the
+open question, body by body — see [Compatibility](../README.md#compatibility), which lists every app-capable model,
+which ones people have confirmed, and which Sony bodies cannot run apps at all.
+
+If you try one, please file a
+[compatibility report](https://github.com/voxivoid/recipe-lab-sony-a6000/issues/new?template=compatibility_report.yml).
+
+## My camera is newer than an A6500 — is there a version for it?
+
+There cannot be. Sony dropped the on-camera app platform after 2016: every body since — A6100, A6400, A6600, A6700,
+A7 III onwards, A9, A1, the ZV and FX cameras, RX100 VA and later — has cryptographically signed firmware and no
+`MENU → Application` at all. Nothing can be installed on them, by this project or anyone else. Those cameras do have
+Picture Profiles and Creative Looks in the menus, which is the feature Recipe Lab exists to make up for.
+
+You may come across a report of Recipe Lab running on one of these. It cannot: check for the Application menu, and if
+it is missing, no app is installed.
+
+## Can I make my own recipes and save them?
+
+Not today. The 77 recipes are built into the app, and you can adjust a recipe's values before storing it — the chips
+in the app row — but there is no way to name and keep your own. It is the most requested feature and it is being
+thought about; nothing is promised.
+
+## Can it use LUTs, like JPEG.CAM does?
+
+No, and not by accident. Recipe Lab never processes an image — it picks camera settings and gets out of the way,
+which is why the look survives with the app closed and why it applies to video too. The A6000's settings store has no
+LUT, no tone curve and no gamma to write, so there is nothing to point a LUT at.
+
+Applying a LUT would mean the app taking the picture itself and re-processing the file, which is a different kind of
+tool — [JPEG.CAM](https://www.jpeg.cam) does exactly that, and is worth a look if that is what you want. It cannot be
+real time, and it cannot touch video.
+
+## What about grain, halation, bloom, or light leaks?
+
+Same wall. Those are image processing, and this app does no image processing — only what the camera's own hardware
+does while it writes the JPEG. Film grain in particular is not a setting the A6000 has.
+
+## Can I map a custom button to launch the app?
+
+No. The camera's custom-key list is fixed in firmware and apps cannot add themselves to it, so the app opens from
+`MENU → Application → Application List`. Changing that would mean custom firmware, which this project does not do.
+
+## Can I get S-Log, V-Log or a flat profile?
+
+Not on this body. The A6000 has no Picture Profile menu and cannot store a gamma curve — the log profiles simply are
+not there to switch on. Sony's camcorder *Cinematone* gamma does exist inside the firmware, but the A6000's camera
+layer neither lists nor accepts it. The flattest thing available is a low-contrast Creative Style recipe, which is
+not the same thing.
+
+## Are there sample photos of each recipe?
+
+Not yet. Straight-out-of-camera frames for 77 recipes need one static scene shot 77 times, and it has not been done.
+Until then the app's live preview is the sample: turn the wheel and the image on the screen is what the camera will
+write.
+
+## Something went wrong
+
+The [Troubleshooting table](../README.md#troubleshooting) covers the common ones. Install and USB problems belong to
+[Sony-PMCA-RE](https://github.com/ma1co/Sony-PMCA-RE/issues), which is what puts apps on the camera; anything about
+the recipes or the app itself belongs [here](https://github.com/voxivoid/recipe-lab-sony-a6000/issues).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "recipe-lab-sony-a6000",
+  "name": "recipe-lab-sony-pmca",
   "version": "0.0.0-managed-by-semantic-release",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "recipe-lab-sony-a6000",
+      "name": "recipe-lab-sony-pmca",
       "version": "0.0.0-managed-by-semantic-release",
       "devDependencies": {
         "@semantic-release/exec": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "recipe-lab-sony-a6000",
+  "name": "recipe-lab-sony-pmca",
   "version": "0.0.0-managed-by-semantic-release",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Closes #12

Recipe Lab has no model check in it — it reaches the settings store through the OpenMemories backup driver, and every Sony body that takes PlayMemories camera apps has that store. The README never said so, and the Reddit threads were full of "will this work on my X?".

Adds a **Compatibility** section between *The recipes* and *Installing*:

- **Cameras that run PlayMemories apps** — table of every app-capable still camera, ✅ where someone has actually run Recipe Lab on it, ❔ otherwise. List derived from [`fwtool.py devices.yml`](https://github.com/ma1co/fwtool.py/blob/master/devices.yml) (the source behind the [OpenMemories device table](https://openmemories.readthedocs.io/devices.html)).
- ✅ so far: **A6000** (built on it, fw 3.21), **A6500**, **A5100**, **A7 II** — all from user reports.
  - A6500: stores and survives a power cycle, but the badge reads `PROTECTED` where the A6000 shows `ACTIVE`.
  - A5100: no **Fn** / **AEL** button on that body, so the brand list and clean-preview toggle are unreachable; the wheel still works.
- Notes the bodies that are app-capable but pointless targets (QX lens cameras, Handycams, action cams) and the two asterisked ones (RX100 II, original RX10 — Sony sold apps for them, but they are absent from the installer's device table).
- **Cameras that cannot run camera apps at all** — everything since the A6500 (signed firmware), so A6100/A6400/A6600/A6700, A7 III onwards, A9/A1/ZV/FX, RX100 VA+, RX10 IV… plus a line pre-empting the "works on my A6400" report going around: those bodies have no `MENU → Application` at all.

Docs only. Nothing in the compatibility claims is checkable by CI — the ✅ rows rest on user reports, and everything else stays ❔ until someone exercises a body **and power-cycles it**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)